### PR TITLE
SQL LocalDB Simplification

### DIFF
--- a/src/Sentinel.Tests/App.config
+++ b/src/Sentinel.Tests/App.config
@@ -1,9 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <section name="system.data.sqlLocalDb" type="System.Data.SqlLocalDb.Configuration.SqlLocalDbConfigurationSection, System.Data.SqlLocalDb" />
+  </configSections>
   <appSettings>
     <add key="ApiUrl" value="http://localhost:55348/" />
     <add key="RedisHost" value="localhost"/>
   </appSettings>
+  <system.data.sqlLocalDb automaticallyDeleteInstanceFiles="true" stopOptions="NoWait" stopTimeout="00:00:10" />
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/Sentinel.Tests/Integration/ClientManagers/SqlServerClientManagerTests.cs
+++ b/src/Sentinel.Tests/Integration/ClientManagers/SqlServerClientManagerTests.cs
@@ -17,7 +17,7 @@
     [Category("Integration")]
     public class SqlServerClientManagerTests
     {
-        private SqlLocalDbInstance instance;
+        private TemporarySqlLocalDbInstance instance;
 
         private string databaseName;
 
@@ -26,14 +26,10 @@
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
-            var localDb = new SqlLocalDbApiWrapper();
-
-            if (!localDb.IsLocalDBInstalled())
+            if (!SqlLocalDbApi.IsLocalDBInstalled())
             {
                 throw new Exception("LocalDB is not installed!");
             }
-
-            var provider = new SqlLocalDbProvider();
 
             this.databaseName = "SqlServerClientManagerTests" + Guid.NewGuid().ToString("N");
 
@@ -41,8 +37,7 @@
             SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
 
             // Create test instance
-            this.instance = provider.CreateInstance(Guid.NewGuid().ToString("N"));
-            this.instance.Start();
+            this.instance = TemporarySqlLocalDbInstance.Create(deleteFiles: true);
 
             // Seed test data
             using (var connection = this.instance.CreateConnection())
@@ -129,7 +124,7 @@
         [TestFixtureTearDown]
         public void TestFixtureTearDown()
         {
-            if (this.instance != null && this.instance.IsRunning)
+            if (this.instance != null)
             {
                 // Delete database
                 using (var connection = this.instance.CreateConnection())
@@ -145,8 +140,8 @@
                         connection.Close();
                     }
                 }
-                
-                this.instance.Stop();
+
+                this.instance.Dispose();
             }
         }
     }

--- a/src/Sentinel.Tests/Integration/ClientManagers/SqlServerClientManagerTests.cs
+++ b/src/Sentinel.Tests/Integration/ClientManagers/SqlServerClientManagerTests.cs
@@ -37,7 +37,7 @@
             SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
 
             // Create test instance
-            this.instance = TemporarySqlLocalDbInstance.Create(deleteFiles: true);
+            this.instance = TemporarySqlLocalDbInstance.Create();
 
             // Seed test data
             using (var connection = this.instance.CreateConnection())

--- a/src/Sentinel.Tests/Integration/TokenManagers/SqlServerTokenRepositoryTests.cs
+++ b/src/Sentinel.Tests/Integration/TokenManagers/SqlServerTokenRepositoryTests.cs
@@ -51,7 +51,7 @@
             SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
 
             // Create test instance
-            this.instance = TemporarySqlLocalDbInstance.Create(deleteFiles: true);
+            this.instance = TemporarySqlLocalDbInstance.Create();
 
             // Seed test data
             using (var connection = this.instance.CreateConnection())

--- a/src/Sentinel.Tests/Integration/TokenManagers/SqlServerTokenRepositoryTests.cs
+++ b/src/Sentinel.Tests/Integration/TokenManagers/SqlServerTokenRepositoryTests.cs
@@ -26,7 +26,7 @@
     public class SqlServerTokenRepositoryTests
     {
         /// <summary>The instance.</summary>
-        private SqlLocalDbInstance instance;
+        private TemporarySqlLocalDbInstance instance;
 
         private string databaseName;
 
@@ -40,14 +40,10 @@
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
-            var localDb = new SqlLocalDbApiWrapper();
-
-            if (!localDb.IsLocalDBInstalled())
+            if (!SqlLocalDbApi.IsLocalDBInstalled())
             {
                 throw new Exception("LocalDB is not installed!");
             }
-
-            var provider = new SqlLocalDbProvider();
 
             this.databaseName = "SqlServerTokenRepositoryTests" + Guid.NewGuid().ToString("N");
 
@@ -55,8 +51,7 @@
             SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
 
             // Create test instance
-            this.instance = provider.CreateInstance(Guid.NewGuid().ToString("N"));
-            this.instance.Start();
+            this.instance = TemporarySqlLocalDbInstance.Create(deleteFiles: true);
 
             // Seed test data
             using (var connection = this.instance.CreateConnection())
@@ -229,7 +224,7 @@
         [TestFixtureTearDown]
         public void TestFixtureTearDown()
         {
-            if (this.instance != null && this.instance.IsRunning)
+            if (this.instance != null)
             {
                 // Delete database
                 using (var connection = this.instance.CreateConnection())
@@ -246,7 +241,7 @@
                     }
                 }
 
-                this.instance.Stop();
+                this.instance.Dispose();
             }
         }
     } 

--- a/src/Sentinel.Tests/Integration/UserManagers/SqlServerUserManagerTests.cs
+++ b/src/Sentinel.Tests/Integration/UserManagers/SqlServerUserManagerTests.cs
@@ -37,7 +37,7 @@
             SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
 
             // Create test instance
-            this.instance = TemporarySqlLocalDbInstance.Create(deleteFiles: true);
+            this.instance = TemporarySqlLocalDbInstance.Create();
 
             // Seed test data
             using (var connection = this.instance.CreateConnection())

--- a/src/Sentinel.Tests/Integration/UserManagers/SqlServerUserManagerTests.cs
+++ b/src/Sentinel.Tests/Integration/UserManagers/SqlServerUserManagerTests.cs
@@ -17,7 +17,7 @@
     [Category("Integration")]
     public class SqlServerUserManagerTests
     {
-        private SqlLocalDbInstance instance;
+        private TemporarySqlLocalDbInstance instance;
 
         private string databaseName;
 
@@ -26,14 +26,10 @@
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
-            var localDb = new SqlLocalDbApiWrapper();
-
-            if (!localDb.IsLocalDBInstalled())
+            if (!SqlLocalDbApi.IsLocalDBInstalled())
             {
                 throw new Exception("LocalDB is not installed!");
             }
-
-            var provider = new SqlLocalDbProvider();
 
             this.databaseName = "SqlServerUserManagerTests_" + Guid.NewGuid().ToString("N");
 
@@ -41,8 +37,7 @@
             SqlMapper.AddTypeMap(typeof(DateTime), DbType.DateTime2);
 
             // Create test instance
-            this.instance = provider.CreateInstance(Guid.NewGuid().ToString("N"));
-            this.instance.Start();
+            this.instance = TemporarySqlLocalDbInstance.Create(deleteFiles: true);
 
             // Seed test data
             using (var connection = this.instance.CreateConnection())
@@ -88,7 +83,7 @@
         [TestFixtureTearDown]
         public void TestFixtureTearDown()
         {
-            if (this.instance != null && this.instance.IsRunning)
+            if (this.instance != null)
             {
                 // Delete database
                 using (var connection = this.instance.CreateConnection())
@@ -105,7 +100,7 @@
                     }
                 }
                 
-                this.instance.Stop();
+                this.instance.Dispose();
             }
         }
     }


### PR DESCRIPTION
I've updated the tests that use the ```SqlLocalDbInstance``` class to use the ```TemporarySqlLocalDbInstance``` class in the System.Data.SqlLocalDb assembly instead to simplify the amount of boilerplate code required to set up an instance.

I've also updated the tests configuration file to adjust some settings for System.Data.SqlLocalDb which should speed up the tests that use it and delete the files that SQL LocalDB leaves behind on disk by default.