### PR TITLE
Fix for refresh token request.

### DIFF
--- a/src/Sentinel.OAuth/Implementation/Managers/TokenManager.cs
+++ b/src/Sentinel.OAuth/Implementation/Managers/TokenManager.cs
@@ -119,13 +119,14 @@
                 {
                     this.logger.DebugFormat("Refresh token is valid. It belongs to the user '{0}', client '{1}' and redirect uri '{2}'", validationResult.Entity.Subject, validationResult.Entity.ClientId, validationResult.Entity.RedirectUri);
 
+                    //When  using a refresh toket to the a token , there is no need to delete it. You mush reuse it for next refresh token requests.
                     // Delete refresh token to prevent it being used again
-                    var deleteResult = await this.TokenRepository.DeleteRefreshToken(validationResult.Entity);
+                    //var deleteResult = await this.TokenRepository.DeleteRefreshToken(validationResult.Entity);
 
-                    if (!deleteResult)
-                    {
-                        this.logger.Error($"Unable to delete used refresh token: {JsonConvert.SerializeObject(validationResult.Entity)}");
-                    }
+                    //if (!deleteResult)
+                    //{
+                    //    this.logger.Error($"Unable to delete used refresh token: {JsonConvert.SerializeObject(validationResult.Entity)}");
+                    //}
 
                     var principal = this.PrincipalProvider.Create(
                         AuthenticationType.OAuth,

--- a/src/Sentinel.OAuth/Providers/OAuth/SentinelRefreshTokenProvider.cs
+++ b/src/Sentinel.OAuth/Providers/OAuth/SentinelRefreshTokenProvider.cs
@@ -44,8 +44,9 @@
         /// <returns/>
         public void CreateRefreshToken(AuthenticationTokenCreateContext context)
         {
-            // Dont create a refresh token if it is a client_credentials request
-            if (context.OwinContext.GetOAuthContext().GrantType == GrantType.ClientCredentials)
+            // Dont create a refresh token if it is a client_credentials request and for refresh token
+            if (context.OwinContext.GetOAuthContext().GrantType == GrantType.ClientCredentials ||
+                context.OwinContext.GetOAuthContext().GrantType == GrantType.RefreshToken)
             {
                 this.options.Logger.Debug("This is a client_credentials request, skipping refresh token creation.");
 
@@ -114,6 +115,12 @@
                             var redirect = principal.Identity.Claims.First(x => x.Type == ClaimType.RedirectUri);
                             var scope = principal.Identity.Claims.FirstOrDefault(x => x.Type == ClaimType.Scope);
 
+                            //Reinject the redirect uri from the request.
+                            if (redirectUri == null)
+                            {
+                                redirectUri = redirect.Value;
+                                context.OwinContext.GetOAuthContext().RedirectUri = redirect.Value;
+                            }
                             /* Override the validation parameters.
                              * This is because OWIN thinks the principal.Identity.Name should 
                              * be the same as the client_id from ValidateClientAuthentication method,


### PR DESCRIPTION
There are a bug when doing a refresh token, when you do it, it delete the refresh token. The standard protocol for OAUTH the refhresh token mantains.
There is no need to regenerate.

Also reinject the redirect uri for refhresh token request.